### PR TITLE
Adding `enableAutoPipelining` in clusterOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ class Redis {
           hosts: cluster.hosts,
         });
         const clusterOptions = {
+          enableAutoPipelining: cluster.autoPipelining,
           clusterRetryStrategy: retryStrategy,
         };
 


### PR DESCRIPTION
`cluster` config can now set `autoPipelining` to `true` if needed